### PR TITLE
If level type is unknown, use Regular

### DIFF
--- a/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
@@ -1512,8 +1512,8 @@ abstract class XmlaOlap4jConnection implements OlapConnection {
             final int levelNumber =
                 integerElement(row, "LEVEL_NUMBER");
             final Integer levelTypeCode = integerElement(row, "LEVEL_TYPE");
-            final Level.Type levelType =
-                Level.Type.getDictionary().forOrdinal(levelTypeCode);
+            Level.Type optionalLevelType = Level.Type.getDictionary().forOrdinal(levelTypeCode);
+            final Level.Type levelType = optionalLevelType == null ? Level.Type.REGULAR : optionalLevelType;
             boolean calculated = (levelTypeCode & MDLEVEL_TYPE_CALCULATED) != 0;
             final int levelCardinality =
                 integerElement(row, "LEVEL_CARDINALITY");


### PR DESCRIPTION
Default LevelType to Regular if no mapping is found.
SQL Server 2014 returns new LevelTypes which are not handled right
now. One such example is LevelType 4484 for MonthOfYear Type.
